### PR TITLE
chore: bump swift-sdk to 0.12.0 to fix NetworkTransport data race

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/JohnSundell/Splash.git", exact: "0.16.0"),
         .package(url: "https://github.com/gonzalezreal/swift-markdown-ui.git", exact: "2.4.0"),
-        .package(url: "https://github.com/modelcontextprotocol/swift-sdk.git", exact: "0.10.2")
+        .package(url: "https://github.com/modelcontextprotocol/swift-sdk.git", from: "0.12.0")
     ],
     targets: [
         .target(


### PR DESCRIPTION
## Summary

Bumps the `modelcontextprotocol/swift-sdk` dependency from `exact: "0.10.2"` to `from: "0.12.0"` so this package can be built under Xcode 26+ with Swift 6 strict-concurrency.

## Why

`swift-sdk@0.10.2` has Swift 6 strict-concurrency violations in `Sources/MCP/Base/Transports/NetworkTransport.swift`:

- Line 581: `sending 'sendContinuationResumed' risks causing data races`
- Line 812: `sending 'receiveContinuationResumed' risks causing data races`

The package opts into strict concurrency itself (`swift-tools-version:6.1`, `swiftSettings: [.enableUpcomingFeature("StrictConcurrency")]`), so any consumer that builds it with the current Xcode toolchain hits these errors.

Upstream fixed this in 0.12.0 (modelcontextprotocol/swift-sdk PR #206 — "fix #203 NetworkTransport race, with main-isolated variables"). Switching from `exact:` to `from: "0.12.0"` lets consumers pick up future patches without further pin updates here.

## Impact

- Anyone consuming this package transitively (e.g. `chat-ai-samples` iOS app) currently can't build on Xcode 26.x without an SPM workaround. After this merges + a release is tagged, they can update normally.

## Test plan

- [ ] CI builds clean against the current Xcode toolchain
- [ ] No API surface change in this package — existing MCP usages compile unchanged
- [ ] Verified locally: `chat-ai-samples` iOS app builds successfully when pointing to this branch

## Linear

[IOS-1656 — Update AI Components sample app and docs to 5.0](https://linear.app/stream/issue/IOS-1656/update-ai-components-sample-app-and-docs-to-50)